### PR TITLE
fix(BUG-008): add error boundary to SceneBeatNode to prevent app-wide crash

### DIFF
--- a/src/Lexical/lexical-playground/src/nodes/SceneBeatNode.tsx
+++ b/src/Lexical/lexical-playground/src/nodes/SceneBeatNode.tsx
@@ -17,6 +17,7 @@ import {
   useEffect,
   useRef,
 } from "react";
+import { SceneBeatErrorBoundary } from "@/components/SceneBeatErrorBoundary";
 import { ChevronDown as ChevronDownIcon, ChevronRight as ChevronRightIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
@@ -630,9 +631,11 @@ export class SceneBeatNode extends DecoratorNode<JSX.Element> {
 
   decorate(): JSX.Element {
     return (
-      <Suspense fallback={null}>
-        <SceneBeatComponent nodeKey={this.__key} />
-      </Suspense>
+      <SceneBeatErrorBoundary nodeKey={this.__key}>
+        <Suspense fallback={null}>
+          <SceneBeatComponent nodeKey={this.__key} />
+        </Suspense>
+      </SceneBeatErrorBoundary>
     );
   }
 }

--- a/src/components/SceneBeatErrorBoundary.tsx
+++ b/src/components/SceneBeatErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  nodeKey: string;
+  children: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class SceneBeatErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error(
+      `[SceneBeatErrorBoundary] Render error in scene beat node "${this.props.nodeKey}":`,
+      error,
+      info.componentStack,
+    );
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div className="relative my-4 rounded-lg border border-destructive/50 bg-card p-4 text-sm text-muted-foreground">
+          <p className="font-medium text-destructive">Scene beat failed to render.</p>
+          <p className="mt-1 text-xs opacity-75">
+            {this.state.error?.message ?? "An unexpected error occurred."}
+          </p>
+          <Button variant="outline" size="sm" className="mt-3" onClick={this.handleRetry}>
+            Retry
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
Closes #8

## Root Cause

In React 18, an uncaught render error inside a `DecoratorNode.decorate()` output unmounts the **entire** component tree, producing a blank/frozen window. `SceneBeatNode.decorate()` wrapped `SceneBeatComponent` in `<Suspense>` but had **no React Error Boundary**, so any render error inside `SceneBeatInner` or its sub-components propagated all the way up and killed the app.

The `LexicalErrorBoundary` used in `Editor.tsx` only covers `RichTextPlugin` / `ContentEditable` — it does not protect `DecoratorNode` render output.

**Why "after extended use":** Session state grows over time (large editor, lorebook entries, generation history). A render error that doesn't occur in a fresh session may surface after extended use due to edge cases on first render of a new `SceneBeatInner`.

## Changes

- **New:** `src/components/SceneBeatErrorBoundary.tsx` — class-based error boundary that catches render errors from `SceneBeatComponent`, shows a fallback card ("Scene beat failed to render" + Retry button), and logs the error + nodeKey to console
- **Edit:** `SceneBeatNode.decorate()` — wrap `<SceneBeatComponent>` in `<SceneBeatErrorBoundary>` outside `<Suspense>`

## Test Plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] In AppImage: use the app for an extended session, press Alt+S — scene beat should open normally
- [ ] If a render error is triggered: the broken scene beat shows the fallback card instead of blanking the entire window; `[SceneBeatErrorBoundary]` error appears in the console log; Retry button attempts re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)