### PR TITLE
fix(bug-011): improve editorial panel drag handle discoverability and persist width

### DIFF
--- a/src/features/chapters/components/StoryEditor.tsx
+++ b/src/features/chapters/components/StoryEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { BookOpen, Tags, Maximize, Minimize, User, Download, StickyNote, MoreVertical, ArrowLeft, FileText, Settings, HelpCircle, ScrollText, Book, Microscope, Loader2, Check } from "lucide-react";
 import { useChapterStore } from "@/features/chapters/stores/useChapterStore";
 import { Button } from "@/components/ui/button";
@@ -51,7 +51,18 @@ type DrawerType = "matchedTags" | "chapterOutline" | "chapterPOV" | "chapterNote
 export function StoryEditor() {
     const [openDrawer, setOpenDrawer] = useState<DrawerType>(null);
     const [isMaximized, setIsMaximized] = useState(false);
-    const [editorialWidth, setEditorialWidth] = useState(() => Math.round(window.innerWidth * 0.6));
+    const EDITORIAL_WIDTH_KEY = 'editorial-panel-width';
+    const [editorialWidth, setEditorialWidth] = useState(() => {
+        try {
+            const saved = localStorage.getItem(EDITORIAL_WIDTH_KEY);
+            if (saved) {
+                const n = parseInt(saved, 10);
+                if (!isNaN(n) && n >= 320) return Math.min(n, window.innerWidth - 80);
+            }
+        } catch { /* localStorage unavailable */ }
+        return Math.round(window.innerWidth * 0.6);
+    });
+    const dragWidthRef = useRef(editorialWidth);
     const { currentChapterId, currentStoryId } = useStoryContext();
     const saveStatus = useChapterStore((s) => s.saveStatus);
     const isMobile = useIsMobile();
@@ -67,11 +78,13 @@ export function StoryEditor() {
                 Math.max(startWidth + (startX - ev.clientX), 320),
                 window.innerWidth - 80
             );
+            dragWidthRef.current = next;
             setEditorialWidth(next);
         };
         const onMouseUp = () => {
             document.removeEventListener('mousemove', onMouseMove);
             document.removeEventListener('mouseup', onMouseUp);
+            try { localStorage.setItem(EDITORIAL_WIDTH_KEY, String(dragWidthRef.current)); } catch { /* ignore */ }
         };
         document.addEventListener('mousemove', onMouseMove);
         document.addEventListener('mouseup', onMouseUp);
@@ -475,7 +488,7 @@ export function StoryEditor() {
             </Sheet>
 
             {/* AI Editorial Sheet */}
-            <Sheet open={openDrawer === "chapterReview"} onOpenChange={(open) => { if (!open) { setOpenDrawer(null); setEditorialWidth(Math.round(window.innerWidth * 0.6)); } }}>
+            <Sheet open={openDrawer === "chapterReview"} onOpenChange={(open) => { if (!open) { setOpenDrawer(null); } }}>
                 <SheetContent
                     side="right"
                     className="h-[100vh] w-full max-w-none overflow-hidden"
@@ -483,7 +496,7 @@ export function StoryEditor() {
                 >
                     {/* Drag handle on the left edge */}
                     <div
-                        className="absolute left-0 top-0 bottom-0 w-2 cursor-col-resize z-10 hover:bg-primary/20 active:bg-primary/30 transition-colors"
+                        className="absolute left-0 top-0 bottom-0 w-3 cursor-col-resize z-10 bg-border/30 hover:bg-primary/40 active:bg-primary/60 transition-colors"
                         onMouseDown={startEditorialDrag}
                     />
                     <SheetHeader>

--- a/src/features/chapters/components/StoryEditor.tsx
+++ b/src/features/chapters/components/StoryEditor.tsx
@@ -495,7 +495,7 @@ export function StoryEditor() {
                 <SheetContent
                     side="right"
                     className="h-[100vh] w-full max-w-none overflow-hidden"
-                    style={{ width: `${editorialWidth}px` }}
+                    style={{ width: `${editorialWidth}px`, maxWidth: 'none' }}
                 >
                     {/* Drag handle on the left edge */}
                     <div

--- a/src/features/chapters/components/StoryEditor.tsx
+++ b/src/features/chapters/components/StoryEditor.tsx
@@ -68,11 +68,13 @@ export function StoryEditor() {
     const isMobile = useIsMobile();
     const navigate = useNavigate();
 
-    const startEditorialDrag = useCallback((e: React.MouseEvent) => {
+    const startEditorialDrag = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
         e.preventDefault();
+        const el = e.currentTarget;
+        el.setPointerCapture(e.pointerId);
         const startX = e.clientX;
         const startWidth = editorialWidth;
-        const onMouseMove = (ev: MouseEvent) => {
+        const onPointerMove = (ev: PointerEvent) => {
             // dragging left increases width (panel is on the right)
             const next = Math.min(
                 Math.max(startWidth + (startX - ev.clientX), 320),
@@ -81,13 +83,14 @@ export function StoryEditor() {
             dragWidthRef.current = next;
             setEditorialWidth(next);
         };
-        const onMouseUp = () => {
-            document.removeEventListener('mousemove', onMouseMove);
-            document.removeEventListener('mouseup', onMouseUp);
+        const onPointerUp = (ev: PointerEvent) => {
+            el.releasePointerCapture(ev.pointerId);
+            el.removeEventListener('pointermove', onPointerMove);
+            el.removeEventListener('pointerup', onPointerUp);
             try { localStorage.setItem(EDITORIAL_WIDTH_KEY, String(dragWidthRef.current)); } catch { /* ignore */ }
         };
-        document.addEventListener('mousemove', onMouseMove);
-        document.addEventListener('mouseup', onMouseUp);
+        el.addEventListener('pointermove', onPointerMove);
+        el.addEventListener('pointerup', onPointerUp);
     }, [editorialWidth]);
 
     const handleOpenDrawer = (drawer: DrawerType) => {
@@ -497,7 +500,7 @@ export function StoryEditor() {
                     {/* Drag handle on the left edge */}
                     <div
                         className="absolute left-0 top-0 bottom-0 w-3 cursor-col-resize z-10 bg-border/30 hover:bg-primary/40 active:bg-primary/60 transition-colors"
-                        onMouseDown={startEditorialDrag}
+                        onPointerDown={startEditorialDrag}
                     />
                     <SheetHeader>
                         <SheetTitle>AI Editorial</SheetTitle>


### PR DESCRIPTION
## Summary

Closes #11

- Widened the drag handle from `w-2` (8px) to `w-3` (12px) and added a faint resting tint (`bg-border/30`) so users can discover it without hovering
- Load saved width from `localStorage` on mount so preferred size survives panel close/reopen
- Persist final width to `localStorage` on drag-end via a `useRef` (avoids stale closure)
- Removed the `onOpenChange` handler that was resetting width to 60% on every close

## Test plan

- [x] Open a chapter, open the AI Editorial panel — drag handle should be faintly visible at left edge
- [x] Drag to resize — panel resizes smoothly
- [x] Close and reopen the panel — width is restored to previous size
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)