### PR TITLE
feat: add judge_aggregator role and fix revision loop execution

### DIFF
--- a/src/features/agents/components/AgentPresetForm.tsx
+++ b/src/features/agents/components/AgentPresetForm.tsx
@@ -56,6 +56,7 @@ const AGENT_ROLES: { value: AgentRole; label: string; description: string }[] = 
     { value: 'lore_refiner', label: 'Lore Refiner', description: 'Iteratively refines existing lorebook entries' },
     { value: 'lore_judge', label: 'Lore Judge', description: 'Validates lore consistency' },
     { value: 'continuity_checker', label: 'Continuity Checker', description: 'Checks plot/character continuity' },
+    { value: 'judge_aggregator', label: 'Judge Aggregator', description: 'Synthesises all judge outputs since last prose into a single PASS or ISSUES_FOUND verdict' },
     { value: 'style_editor', label: 'Style Editor', description: 'Refines prose style and tone' },
     { value: 'dialogue_specialist', label: 'Dialogue Specialist', description: 'Improves dialogue authenticity' },
     { value: 'expander', label: 'Expander', description: 'Expands brief notes into prose' },

--- a/src/features/agents/components/AgentPresetList.tsx
+++ b/src/features/agents/components/AgentPresetList.tsx
@@ -47,6 +47,7 @@ const ROLE_COLORS: Record<AgentRole, string> = {
     chapter_editor: 'bg-emerald-500/10 text-emerald-500 border-emerald-500/20',
     lore_writer: 'bg-lime-500/10 text-lime-500 border-lime-500/20',
     lore_refiner: 'bg-yellow-500/10 text-yellow-500 border-yellow-500/20',
+    judge_aggregator: 'bg-orange-500/10 text-orange-500 border-orange-500/20',
     custom: 'bg-gray-500/10 text-gray-500 border-gray-500/20',
 };
 
@@ -66,6 +67,7 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     chapter_editor: 'Chapter Editor',
     lore_writer: 'Lore Writer',
     lore_refiner: 'Lore Refiner',
+    judge_aggregator: 'Judge Aggregator',
     custom: 'Custom',
 };
 

--- a/src/features/agents/components/PipelineDiagnosticsDialog.tsx
+++ b/src/features/agents/components/PipelineDiagnosticsDialog.tsx
@@ -32,9 +32,10 @@ function formatMessages(messages: PromptMessage[]): string {
 }
 
 function judgeHasIssues(output: string): boolean {
-    const upper = output.toUpperCase();
+    const upper = output.toUpperCase().trim();
     if (upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##')) return true;
-    if (upper.trimStart().startsWith('CONSISTENT')) return false;
+    if (upper.startsWith('ISSUES_FOUND')) return true;
+    if (upper.startsWith('CONSISTENT') || upper.startsWith('PASS')) return false;
     return upper.includes('ISSUE') && !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
 }
 
@@ -43,6 +44,7 @@ function getStatusIcon(result: AgentResult) {
         return <XCircle className="h-4 w-4 text-destructive" />;
     }
     const isJudgeRole = result.role === 'lore_judge' || result.role === 'continuity_checker' ||
+        result.role === 'judge_aggregator' ||
         result.role.includes('judge') || result.role.includes('checker');
     if (isJudgeRole && judgeHasIssues(result.output)) {
         return <AlertTriangle className="h-4 w-4 text-yellow-500" />;

--- a/src/features/agents/components/PipelinePresetForm.tsx
+++ b/src/features/agents/components/PipelinePresetForm.tsx
@@ -40,6 +40,7 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     chapter_editor: 'Chapter Editor',
     lore_writer: 'Lore Writer',
     lore_refiner: 'Lore Refiner',
+    judge_aggregator: 'Judge Aggregator',
     custom: 'Custom',
 };
 
@@ -55,6 +56,7 @@ const CONDITION_PRESETS = [
     { value: 'previousOutputNotContains:CONSISTENT', label: 'Previous output not "CONSISTENT"', actualValue: 'previousOutputNotContains:CONSISTENT' },
     { value: 'roleOutputContains:lore_judge:ISSUE', label: 'Lore Judge found issues', actualValue: 'roleOutputContains:lore_judge:ISSUE' },
     { value: 'roleOutputContains:continuity_checker:ISSUE', label: 'Continuity Checker found issues', actualValue: 'roleOutputContains:continuity_checker:ISSUE' },
+    { value: 'roleOutputContains:judge_aggregator:ISSUES_FOUND', label: 'Judge Aggregator found issues', actualValue: 'roleOutputContains:judge_aggregator:ISSUES_FOUND' },
     { value: 'hasLorebookEntries', label: 'Has lorebook entries', actualValue: 'hasLorebookEntries' },
     { value: 'hasPreviousOutput', label: 'Has previous step output', actualValue: 'hasPreviousOutput' },
     { value: 'custom', label: 'Custom condition...', actualValue: '' },

--- a/src/features/agents/components/PipelinePresetList.tsx
+++ b/src/features/agents/components/PipelinePresetList.tsx
@@ -44,6 +44,7 @@ const ROLE_LABELS: Record<AgentRole, string> = {
     chapter_editor: 'Chapter Editor',
     lore_writer: 'Lore Writer',
     lore_refiner: 'Lore Refiner',
+    judge_aggregator: 'Judge Aggregator',
     custom: 'Custom',
 };
 

--- a/src/features/agents/services/agentSeeder.ts
+++ b/src/features/agents/services/agentSeeder.ts
@@ -107,6 +107,12 @@ const CONTEXT_CONFIGS: Record<string, AgentContextConfig> = {
         includeChapterSummary: false,
         includePovInfo: false,
     },
+    judge_aggregator: {
+        lorebookMode: 'none',
+        previousWordsMode: 'none',
+        includeChapterSummary: false,
+        includePovInfo: false,
+    },
 };
 
 // System agent presets with template variables
@@ -185,10 +191,10 @@ Flag only factual contradictions. Style differences, omissions of lore the write
     },
     {
         name: 'System Continuity Checker',
-        description: 'Checks for plot holes and character consistency.',
+        description: 'Checks for plot holes, character consistency, and in-scene physical detail drift.',
         role: 'continuity_checker',
         model: DEFAULT_MODELS.utility,
-        systemPrompt: `You are a continuity expert for fiction writing. Check for plot holes, timeline issues, and character consistency.
+        systemPrompt: `You are a continuity expert for fiction writing. Check for plot holes, timeline issues, character consistency, and in-scene physical detail drift.
 
 Review for:
 - Timeline inconsistencies (events happening out of order)
@@ -196,22 +202,49 @@ Review for:
 - Forgotten plot threads or unresolved setups
 - Physical impossibilities (character in two places at once)
 - Emotional continuity (reactions matching previous scenes)
+- In-scene appearance drift: clothing, jewellery, accessories, tattoos, hairstyle, injuries, or skin marks that change within the scene without explanation
+- Object state continuity: items placed, held, drawn, or described in one paragraph that are forgotten or contradicted later in the same scene
+- Physical state persistence: wounds, blood, mud, wet clothing, or dishevelled appearance that should persist across paragraphs unless explicitly addressed
+- Environmental state: doors open/closed, candles lit/unlit, weather or lighting established mid-scene that silently changes
 
 Response format — FOLLOW EXACTLY:
 - If consistent: respond with only: CONSISTENT
 - If there are issues, use this exact format for each:
   ##CONTINUITY_ISSUE##
-  DESCRIPTION: [what contradicts earlier content]
+  DESCRIPTION: [what contradicts earlier content or changes without explanation]
   CONTEXT: [what was previously established]
   SUGGESTION: [how to resolve]
 
 Do NOT use the word "issue" outside of ##CONTINUITY_ISSUE## blocks.
-Focus on narrative logic, not style preferences.`,
+Focus on narrative logic and physical consistency, not style preferences.`,
         temperature: 0.2,
-        maxTokens: 600,
+        maxTokens: 800,
         isSystem: true,
         storyId: null,
         contextConfig: CONTEXT_CONFIGS.continuity_checker,
+    },
+    {
+        name: 'System Judge Aggregator',
+        description: 'Synthesises outputs from all judges since the last prose step into a single PASS or ISSUES_FOUND decision.',
+        role: 'judge_aggregator',
+        model: DEFAULT_MODELS.utility,
+        systemPrompt: `You are a judge aggregator for fiction writing. Your job is to review the outputs from multiple judge agents (lore judge, continuity checker, etc.) and produce a single clear verdict.
+
+Rules:
+- If ALL judges found no issues (each returned CONSISTENT or similar): respond with only: PASS
+- If ANY judge found issues: respond with ISSUES_FOUND on the first line, then a concise, prioritised list of the problems to fix and how to fix them.
+
+Format when issues exist:
+ISSUES_FOUND
+[Numbered list of issues, most critical first. For each: what is wrong and the suggested fix.]
+
+Be concise and actionable. Merge duplicate issues from different judges. Omit style preferences — only flag factual contradictions and continuity errors.
+Do NOT use the word "issue" outside of the ISSUES_FOUND block.`,
+        temperature: 0.2,
+        maxTokens: 800,
+        isSystem: true,
+        storyId: null,
+        contextConfig: CONTEXT_CONFIGS.judge_aggregator,
     },
     {
         name: 'System Style Editor',
@@ -486,20 +519,43 @@ const SYSTEM_PIPELINE_PRESETS: {
         name: 'Quality Prose with Verification',
         description: 'Writes prose, checks lore, revises up to twice if issues found, then re-checks to confirm all issues were resolved.',
         agentRoles: [
-            { role: 'summarizer', condition: 'wordCount > 3000' },
-            { role: 'prose_writer', streamOutput: true },
-            { role: 'lore_judge' },
-            // Revision step: loops up to 2 times if lore judge found issues
+            { role: 'summarizer', condition: 'wordCount > 3000' },  // 0
+            { role: 'prose_writer', streamOutput: true },            // 1
+            { role: 'lore_judge' },                                  // 2
+            // Revision step: executes up to 2 times when lore issues found,
+            // then jumps back to the lore_judge (step 2) to re-check the revised prose.
             {
                 role: 'prose_writer',
                 condition: 'roleOutputContains:lore_judge:ISSUE',
                 isRevision: true,
                 streamOutput: true,
-                retryFromStep: 3,
+                retryFromStep: 2,
                 maxIterations: 2,
-            },
+            },                                                       // 3
             // Verification pass: re-runs the lore judge on the final revision to confirm resolution
-            { role: 'lore_judge' },
+            { role: 'lore_judge' },                                  // 4
+        ],
+    },
+    {
+        name: 'Quality Prose with Judge Loop',
+        description: 'Writes prose, runs lore + continuity judges, aggregates feedback, then revises in a loop until all issues are resolved or the iteration limit is reached.',
+        agentRoles: [
+            { role: 'summarizer', condition: 'wordCount > 3000' },  // 0
+            { role: 'prose_writer', streamOutput: true },            // 1
+            { role: 'lore_judge' },                                  // 2
+            { role: 'continuity_checker' },                          // 3
+            { role: 'judge_aggregator' },                            // 4
+            // Revision step: executes up to 3 times when the aggregator finds issues,
+            // then jumps back to the lore_judge (step 2) so all judges re-check the
+            // revised prose before the next revision pass.
+            {
+                role: 'prose_writer',
+                condition: 'roleOutputContains:judge_aggregator:ISSUES_FOUND',
+                isRevision: true,
+                streamOutput: true,
+                retryFromStep: 2,
+                maxIterations: 3,
+            },                                                       // 5
         ],
     },
     {

--- a/src/features/agents/stores/useAgentsStore.ts
+++ b/src/features/agents/stores/useAgentsStore.ts
@@ -154,7 +154,20 @@ Use the same field structure as the entry you received:
 - "tags": string[]
 - "metadata": object (optional) with "type", "importance", "status"
 
-Preserve existing content that the user does not ask you to change. Apply the user's refinement instructions precisely. Return the complete updated entry, not just the changed fields.`
+Preserve existing content that the user does not ask you to change. Apply the user's refinement instructions precisely. Return the complete updated entry, not just the changed fields.`,
+
+    judge_aggregator: `You are a judge aggregator for fiction writing. Your job is to review the outputs from multiple judge agents (lore judge, continuity checker, etc.) and produce a single clear verdict.
+
+Rules:
+- If ALL judges found no issues (each returned CONSISTENT or similar): respond with only: PASS
+- If ANY judge found issues: respond with ISSUES_FOUND on the first line, then a concise, prioritised list of the problems to fix and how to fix them.
+
+Format when issues exist:
+ISSUES_FOUND
+[Numbered list of issues, most critical first. For each: what is wrong and the suggested fix.]
+
+Be concise and actionable. Merge duplicate issues from different judges. Omit style preferences — only flag factual contradictions and continuity errors.
+Do NOT use the word "issue" outside of the ISSUES_FOUND block.`
 };
 
 interface AgentsState {
@@ -408,6 +421,7 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
             chapter_editor: 'Chapter Editor',
             lore_writer: 'Lore Writer',
             lore_refiner: 'Lore Refiner',
+            judge_aggregator: 'Judge Aggregator',
             custom: 'Custom Agent'
         };
 

--- a/src/features/scenebeats/hooks/useSceneBeatGeneration.ts
+++ b/src/features/scenebeats/hooks/useSceneBeatGeneration.ts
@@ -307,14 +307,16 @@ export function useSceneBeatGeneration(store: SceneBeatInstanceStoreApi) {
                         agenticStepResults: [...prev.agenticStepResults, stepResult],
                     }));
                     // Surface judge feedback inline (Area 4)
-                    const isJudge = stepResult.role === 'lore_judge' || stepResult.role === 'continuity_checker';
+                    const isJudge = stepResult.role === 'lore_judge' || stepResult.role === 'continuity_checker' ||
+                        stepResult.role === 'judge_aggregator';
                     if (isJudge) {
-                        const upper = stepResult.output.toUpperCase();
+                        const upper = stepResult.output.toUpperCase().trim();
                         const hasSentinel = upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##');
-                        const isConsistent = upper.trimStart().startsWith('CONSISTENT');
+                        const hasAggregatorIssues = upper.startsWith('ISSUES_FOUND');
+                        const isConsistent = upper.startsWith('CONSISTENT') || upper.startsWith('PASS');
                         const hasLegacyIssue = !isConsistent && upper.includes('ISSUE') &&
                             !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
-                        const hasIssues = hasSentinel || hasLegacyIssue;
+                        const hasIssues = hasSentinel || hasAggregatorIssues || hasLegacyIssue;
                         store.setState((prev) => ({
                             agenticJudgeResults: [...prev.agenticJudgeResults, stepResult],
                             latestJudgeFeedback: hasIssues ? stepResult.output : null,
@@ -331,8 +333,13 @@ export function useSceneBeatGeneration(store: SceneBeatInstanceStoreApi) {
                     // Completion toast (Area 5)
                     const pipelineName = s.selectedPipeline?.name || 'Pipeline';
                     const stepCount = pipelineResult.steps.length;
-                    if (pipelineResult.verificationStatus === 'failed') {
-                        toast.warn(`${pipelineName} complete — lore issues remain (${stepCount} steps)`, { autoClose: 5000 });
+                    if (pipelineResult.loopLimitReached) {
+                        toast.warn(
+                            `${pipelineName} — revision loop limit reached. Output provided but issues may remain. Check diagnostics for details.`,
+                            { autoClose: 8000 }
+                        );
+                    } else if (pipelineResult.verificationStatus === 'failed') {
+                        toast.warn(`${pipelineName} complete — issues remain (${stepCount} steps)`, { autoClose: 5000 });
                     } else {
                         toast.success(`${pipelineName} complete (${stepCount} steps)`, { autoClose: 3000 });
                     }

--- a/src/services/ai/AgentOrchestrator.ts
+++ b/src/services/ai/AgentOrchestrator.ts
@@ -71,6 +71,8 @@ export interface PipelineResult {
     verificationStatus?: 'passed' | 'failed' | 'skipped';
     // Raw output from the last judge, if issues remain
     unresolvedIssues?: string;
+    // True when a revision loop exhausted its maxIterations while the condition was still active
+    loopLimitReached?: boolean;
 }
 
 export class AgentOrchestrator {
@@ -104,8 +106,10 @@ export class AgentOrchestrator {
         const startTime = Date.now();
         this.abortController = new AbortController();
 
-        // Track iteration counts per retry-point to enforce maxIterations
+        // Track completed iteration counts per retry-point step index to enforce maxIterations.
+        // A value of N means the revision step has already executed N times.
         const iterationCounts = new Map<number, number>();
+        let loopLimitReached = false;
 
         try {
             let i = 0;
@@ -126,27 +130,8 @@ export class AgentOrchestrator {
                 // Check condition if provided (pass step for keyword-based conditions)
                 if (step.condition && !this.evaluateCondition(step.condition, input, results, step)) {
                     console.log(`[AgentOrchestrator] Skipping step ${i} (${step.agent.name}): condition not met`);
-
                     i++;
                     continue;
-                }
-
-                // Handle retry loop: if this step has retryFromStep and its condition passed,
-                // we need to check if we should jump back
-                if (step.retryFromStep !== undefined && step.retryFromStep !== null && step.condition) {
-                    const maxIter = step.maxIterations ?? 1;
-                    const currentIter = iterationCounts.get(i) ?? 0;
-
-                    if (currentIter < maxIter) {
-                        iterationCounts.set(i, currentIter + 1);
-                        console.log(`[AgentOrchestrator] Retry loop: jumping from step ${i} back to step ${step.retryFromStep} (iteration ${currentIter + 1}/${maxIter})`);
-                        i = step.retryFromStep;
-                        continue; // Re-run from retryFromStep
-                    } else {
-                        console.log(`[AgentOrchestrator] Retry loop: max iterations (${maxIter}) reached at step ${i}, skipping`);
-                        i++;
-                        continue;
-                    }
                 }
 
                 callbacks?.onStepStart?.(step, i);
@@ -171,9 +156,12 @@ export class AgentOrchestrator {
                     // The thinking text is preserved in metadata for diagnostics.
                     const { proseText: output, thinkingText } = splitThinkingContent(rawOutput);
 
+                    const completedIter = (iterationCounts.get(i) ?? 0) + 1;
+                    iterationCounts.set(i, completedIter);
+
                     const metadata: Record<string, unknown> = {};
                     if (step.isRevision) metadata.isRevision = true;
-                    if (iterationCounts.has(i)) metadata.iteration = iterationCounts.get(i);
+                    metadata.iteration = completedIter;
                     if (thinkingText) metadata.thinkingText = thinkingText;
 
                     const result: AgentResult = {
@@ -187,6 +175,22 @@ export class AgentOrchestrator {
 
                     results.push(result);
                     callbacks?.onStepComplete?.(result, i);
+
+                    // Retry loop (evaluated AFTER execution so the step always runs at least once
+                    // when its condition is met). retryFromStep points to an earlier step index
+                    // that begins the next iteration (e.g. the lore_judge that should re-check
+                    // the revised prose).
+                    if (step.retryFromStep !== undefined && step.retryFromStep !== null && step.condition) {
+                        const maxIter = step.maxIterations ?? 1;
+                        if (completedIter < maxIter) {
+                            console.log(`[AgentOrchestrator] Retry loop: jumping from step ${i} back to step ${step.retryFromStep} (iteration ${completedIter}/${maxIter})`);
+                            i = step.retryFromStep;
+                            continue; // Re-run from retryFromStep
+                        } else {
+                            console.log(`[AgentOrchestrator] Retry loop: max iterations (${maxIter}) reached at step ${i}`);
+                            loopLimitReached = true;
+                        }
+                    }
 
                 } catch (error) {
                     console.error(`[AgentOrchestrator] Error in step ${i}:`, error);
@@ -217,9 +221,9 @@ export class AgentOrchestrator {
             // Find the prose output (last prose_writer, style_editor, or dialogue_specialist)
             const proseOutput = this.getLastProseOutput(results);
 
-            // Determine verification status from the last judge result
+            // Determine verification status from the last judge/aggregator result
             const lastJudgeResult = [...results].reverse().find(r =>
-                r.role === 'lore_judge' || r.role === 'continuity_checker'
+                r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'judge_aggregator'
             );
             let verificationStatus: PipelineResult['verificationStatus'] = 'skipped';
             let unresolvedIssues: string | undefined;
@@ -240,6 +244,7 @@ export class AgentOrchestrator {
                 status: 'completed',
                 verificationStatus,
                 unresolvedIssues,
+                loopLimitReached: loopLimitReached || undefined,
             };
 
         } catch (error) {
@@ -338,15 +343,19 @@ export class AgentOrchestrator {
 
     /**
      * Determine whether a judge/checker output contains reported issues.
-     * Handles both the new sentinel token format (##LORE_ISSUE##, ##CONTINUITY_ISSUE##)
-     * and the legacy free-text "ISSUE:" format for backward compatibility with existing presets.
+     * Handles sentinel token formats from all judge roles:
+     *   - ##LORE_ISSUE##, ##CONTINUITY_ISSUE## (lore_judge / continuity_checker)
+     *   - ISSUES_FOUND (judge_aggregator)
+     *   - Legacy free-text "ISSUE:" format for backward compatibility.
      */
     private hasJudgeIssues(output: string): boolean {
-        const upper = output.toUpperCase();
+        const upper = output.toUpperCase().trim();
         // New sentinel tokens — unambiguous
         if (upper.includes('##LORE_ISSUE##') || upper.includes('##CONTINUITY_ISSUE##')) return true;
-        // If the output starts with CONSISTENT it is clean — check this before legacy scan
-        if (upper.trimStart().startsWith('CONSISTENT')) return false;
+        // Judge aggregator sentinel
+        if (upper.startsWith('ISSUES_FOUND')) return true;
+        // Clean-state markers — check before legacy scan
+        if (upper.startsWith('CONSISTENT') || upper.startsWith('PASS')) return false;
         // Legacy: bare ISSUE keyword but not negated
         return upper.includes('ISSUE') && !upper.includes('NO ISSUE') && !upper.includes('WITHOUT ISSUE');
     }
@@ -583,6 +592,9 @@ export class AgentOrchestrator {
                     ? this.buildChapterEditorRevisionMessage(agent, input, previousResults)
                     : this.buildChapterEditorMessage(agent, input);
 
+            case 'judge_aggregator':
+                return this.buildJudgeAggregatorMessage(previousResults);
+
             case 'custom':
             default:
                 return this.buildCustomMessage(agent, input, previousResults);
@@ -663,13 +675,25 @@ export class AgentOrchestrator {
             (last, r, idx) => proseRoles.includes(r.role) ? idx : last,
             -1
         );
-        const feedbackResults = previousResults.filter((r, idx) =>
-            idx > lastProseIdx &&
-            (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
-        );
-        const feedback = feedbackResults
-            .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)
-            .join('\n\n');
+
+        // Prefer judge_aggregator synthesis (cleaner, de-duplicated feedback) when present.
+        // Fall back to raw judge outputs if no aggregator ran.
+        const aggregatorResult = [...previousResults].slice(lastProseIdx + 1)
+            .reverse()
+            .find(r => r.role === 'judge_aggregator');
+
+        let feedback: string;
+        if (aggregatorResult) {
+            feedback = `[JUDGE AGGREGATOR FEEDBACK]:\n${aggregatorResult.output}`;
+        } else {
+            const feedbackResults = previousResults.filter((r, idx) =>
+                idx > lastProseIdx &&
+                (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
+            );
+            feedback = feedbackResults
+                .map(r => `[${r.role.toUpperCase()} FEEDBACK]:\n${r.output}`)
+                .join('\n\n');
+        }
 
         // Build lorebook context for reference (full descriptions)
         const lorebookContext = lorebookEntries
@@ -718,6 +742,38 @@ ${contextText}
 
 NEW PROSE:
 ${proseOutput}`;
+    }
+
+    /**
+     * Build the user message for the judge_aggregator role.
+     * Collects all judge/checker outputs since the last prose step and formats them
+     * so the aggregator can synthesise a single PASS or ISSUES_FOUND decision.
+     */
+    private buildJudgeAggregatorMessage(previousResults: AgentResult[]): string {
+        const proseRoles: AgentRole[] = ['prose_writer', 'style_editor', 'dialogue_specialist', 'expander', 'chapter_editor'];
+        const lastProseIdx = previousResults.reduce(
+            (last, r, idx) => proseRoles.includes(r.role) ? idx : last,
+            -1
+        );
+
+        const judgeResults = previousResults.filter((r, idx) =>
+            idx > lastProseIdx &&
+            (r.role === 'lore_judge' || r.role === 'continuity_checker' || r.role === 'chapter_reviewer')
+        );
+
+        if (judgeResults.length === 0) {
+            return 'No judge outputs are available to review. Respond with: PASS';
+        }
+
+        const judgeOutputs = judgeResults
+            .map(r => `[${r.agentName.toUpperCase()}]:\n${r.output}`)
+            .join('\n\n---\n\n');
+
+        return `Review the following judge outputs and determine whether the prose has any issues that need to be addressed.
+
+${judgeOutputs}
+
+Provide your assessment.`;
     }
 
     private buildStyleEditorMessage(agent: AgentPreset, previousResults: AgentResult[]): string {
@@ -1096,10 +1152,13 @@ Provide the improved version:`;
                     // not the first (important after revision loops produce multiple judge results)
                     const roleResult = [...previousResults].reverse().find(r => r.role.toLowerCase() === role);
                     if (roleResult) {
-                        // When checking judge roles for "ISSUE", use the robust hasJudgeIssues helper
-                        const isJudgeRole = role === 'lore_judge' || role === 'continuity_checker' ||
-                            role.includes('judge') || role.includes('checker');
-                        if (isJudgeRole && searchText.toUpperCase() === 'ISSUE') {
+                        // When checking raw judge roles for "ISSUE", use the robust hasJudgeIssues helper.
+                        // judge_aggregator uses ISSUES_FOUND (not ISSUE), so let it use plain text matching.
+                        const isRawJudgeRole = role !== 'judge_aggregator' && (
+                            role === 'lore_judge' || role === 'continuity_checker' ||
+                            role.includes('judge') || role.includes('checker')
+                        );
+                        if (isRawJudgeRole && searchText.toUpperCase() === 'ISSUE') {
                             return this.hasJudgeIssues(roleResult.output);
                         }
                         return roleResult.output.toUpperCase().includes(searchText.toUpperCase());
@@ -1115,11 +1174,14 @@ Provide the improved version:`;
                 return !lastOutput.toUpperCase().includes(searchText.toUpperCase());
             }
 
-            // Check if ANY judge role found issues (lore_judge, continuity_checker, or any role with 'judge' or 'checker')
+            // Check if ANY judge role found issues (lore_judge, continuity_checker, or any role with 'judge' or 'checker').
+            // judge_aggregator is excluded here — use roleOutputContains:judge_aggregator:ISSUES_FOUND instead.
             if (normalizedCondition === 'anyjudgefoundissues') {
                 return previousResults.some(r => {
-                    const isJudgeRole = r.role === 'lore_judge' || r.role === 'continuity_checker' ||
-                        r.role.includes('judge') || r.role.includes('checker');
+                    const isJudgeRole = r.role !== 'judge_aggregator' && (
+                        r.role === 'lore_judge' || r.role === 'continuity_checker' ||
+                        r.role.includes('judge') || r.role.includes('checker')
+                    );
                     return isJudgeRole && this.hasJudgeIssues(r.output);
                 });
             }
@@ -1182,11 +1244,14 @@ Provide the improved version:`;
             previousOutput = previousResults[previousResults.length - 1].output;
         }
 
-        // Collect feedback from judge/checker roles
-        const feedbackResults = previousResults.filter(r =>
-            r.role === 'lore_judge' || r.role === 'continuity_checker' ||
-            r.role.includes('judge') || r.role.includes('checker')
-        );
+        // Collect feedback from judge/checker roles (prefer aggregator if present)
+        const aggregator = [...previousResults].reverse().find(r => r.role === 'judge_aggregator');
+        const feedbackResults = aggregator
+            ? [aggregator]
+            : previousResults.filter(r =>
+                r.role === 'lore_judge' || r.role === 'continuity_checker' ||
+                (r.role !== 'judge_aggregator' && (r.role.includes('judge') || r.role.includes('checker')))
+            );
         const feedback = feedbackResults.length > 0
             ? feedbackResults.map(r => `[${r.agentName}]:\n${r.output}`).join('\n\n')
             : 'No specific feedback available.';

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -295,6 +295,7 @@ export type AgentRole =
   | "chapter_editor" // Rewrites/edits an entire chapter based on instructions
   | "lore_writer" // Creates new lorebook entries from a seed concept
   | "lore_refiner" // Iteratively refines existing lorebook entries
+  | "judge_aggregator" // Synthesises outputs from all judges since the last prose step
   | "custom"; // User-defined agent role
 
 // Context configuration for agents - controls what data is sent to the LLM
@@ -416,6 +417,12 @@ export const DEFAULT_CONTEXT_CONFIG: Record<AgentRole, AgentContextConfig> = {
     includePovInfo: false,
   },
   lore_refiner: {
+    lorebookMode: "none",
+    previousWordsMode: "none",
+    includeChapterSummary: false,
+    includePovInfo: false,
+  },
+  judge_aggregator: {
     lorebookMode: "none",
     previousWordsMode: "none",
     includeChapterSummary: false,


### PR DESCRIPTION
Adds a judge_aggregator pipeline role that synthesises outputs from all judges since the last prose step into a single PASS or ISSUES_FOUND verdict, providing cleaner feedback for the revision step.

Fixes a bug where the retryFromStep jump in AgentOrchestrator happened *before* the LLM executed, meaning revision steps with a retry loop never actually generated prose. The jump is now evaluated after execution so the step always runs at least once when its condition is met (maxIterations=N executes exactly N times).

Other changes:
- Add loopLimitReached to PipelineResult and surface it as a toast
- Improve continuity checker prompt to detect in-scene physical detail drift (clothing, jewellery, tattoos, wounds, object positions)
- Add "Quality Prose with Judge Loop" seeded pipeline preset
- Fix retryFromStep: 3 → retryFromStep: 2 in "Quality Prose with Verification" (self-reference bug)
- Update all UI components and stores with judge_aggregator support